### PR TITLE
fix: Admin now lands in students tab after loading in

### DIFF
--- a/ViewModels/AdminDashboardViewModel.cs
+++ b/ViewModels/AdminDashboardViewModel.cs
@@ -64,6 +64,9 @@ namespace LaboratorySitInSystem.ViewModels
             LogoutCommand = new RelayCommand(ExecuteLogout);
 
             RefreshDashboard();
+            
+            // Set initial tab to Students
+            CurrentSubView = new StudentManagementViewModel(_studentRepo);
         }
 
         public void RefreshDashboard()


### PR DESCRIPTION
## Description
Fixed: the admin user landing, now the admin lands in students tab.

## Evidence
<img width="975" height="632" alt="image" src="https://github.com/user-attachments/assets/9d9f0d1d-2151-44c6-99cd-229ffab491be" />
