### PR TITLE
fix: build error

### DIFF
--- a/Helpers/Converters.cs
+++ b/Helpers/Converters.cs
@@ -104,4 +104,38 @@ namespace LaboratorySitInSystem.Helpers
             throw new NotSupportedException();
         }
     }
+
+    public class DotColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool isScheduled && isScheduled)
+            {
+                return new SolidColorBrush(Colors.Green);
+            }
+            return new SolidColorBrush(Colors.Orange);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    public class DotBorderConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool isScheduled && isScheduled)
+            {
+                return new SolidColorBrush(Color.FromRgb(0, 100, 0)); // Dark green
+            }
+            return new SolidColorBrush(Color.FromRgb(200, 100, 0)); // Dark orange
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
 }


### PR DESCRIPTION
## Description
Fixed the build error. The error shows that DotColorConverter doesn't exist in the XML namespace.

## Evidence
Attach or paste a screenshot/photo below as evidence.
<img width="652" height="239" alt="image" src="https://github.com/user-attachments/assets/7b9f83dd-5c2b-412a-a0fa-556567a8f4cd" />

<img width="671" height="250" alt="image" src="https://github.com/user-attachments/assets/0a997ce7-d8f0-4fa4-9336-c82c5018b9db" />

