### PR TITLE
fix: can't rejoin after ending session early

### DIFF
--- a/DataAccess/ISessionRepository.cs
+++ b/DataAccess/ISessionRepository.cs
@@ -15,5 +15,6 @@ namespace LaboratorySitInSystem.DataAccess
         int GetStudentSitInCount(string studentId);
         List<SitInSession> GetStudentRecentHistory(string studentId, int limit);
         void EndSessionEarly(int sessionId, DateTime endTime);
+        bool HasEndedSessionEarlyToday(string studentId, string subjectName, DateTime currentDate);
     }
 }

--- a/DataAccess/SessionRepository.cs
+++ b/DataAccess/SessionRepository.cs
@@ -173,6 +173,24 @@ namespace LaboratorySitInSystem.DataAccess
             command.ExecuteNonQuery();
         }
 
+        public bool HasEndedSessionEarlyToday(string studentId, string subjectName, DateTime currentDate)
+        {
+            using var connection = DatabaseHelper.GetConnection();
+            connection.Open();
+            using var command = new MySqlCommand(
+                "SELECT COUNT(*) FROM sitin_sessions " +
+                "WHERE student_id = @studentId " +
+                "AND subject_name = @subjectName " +
+                "AND DATE(start_time) = DATE(@currentDate) " +
+                "AND early_ended = TRUE",
+                connection);
+            command.Parameters.AddWithValue("@studentId", studentId);
+            command.Parameters.AddWithValue("@subjectName", subjectName);
+            command.Parameters.AddWithValue("@currentDate", currentDate);
+            var count = Convert.ToInt32(command.ExecuteScalar());
+            return count > 0;
+        }
+
         private static SitInSession ReadSession(MySqlDataReader reader)
         {
             return new SitInSession

--- a/Database/test_early_end_prevention.sql
+++ b/Database/test_early_end_prevention.sql
@@ -1,0 +1,47 @@
+-- Test script for early end prevention functionality
+USE laboratory_sitin;
+
+-- Show current sessions and their early_ended status
+SELECT 
+    'CURRENT SESSIONS' as info,
+    session_id,
+    student_id,
+    subject_name,
+    start_time,
+    end_time,
+    early_ended,
+    CASE 
+        WHEN end_time IS NULL THEN 'ACTIVE'
+        WHEN early_ended = TRUE THEN 'ENDED EARLY'
+        ELSE 'COMPLETED NORMALLY'
+    END as session_status
+FROM sitin_sessions
+ORDER BY start_time DESC;
+
+-- Check for students who ended sessions early today
+SELECT 
+    'STUDENTS WHO ENDED EARLY TODAY' as info,
+    student_id,
+    subject_name,
+    start_time,
+    end_time,
+    'CANNOT REJOIN TODAY' as rejoin_status
+FROM sitin_sessions
+WHERE DATE(start_time) = CURDATE()
+  AND early_ended = TRUE
+ORDER BY student_id, subject_name;
+
+-- Test query: Check if a specific student ended early for a subject today
+-- (This is what the HasEndedSessionEarlyToday method does)
+SELECT 
+    'TEST: Check if student ended early today' as test_case,
+    COUNT(*) as early_end_count,
+    CASE 
+        WHEN COUNT(*) > 0 THEN 'BLOCKED - Cannot rejoin'
+        ELSE 'ALLOWED - Can sit in'
+    END as access_status
+FROM sitin_sessions 
+WHERE student_id = '23123'  -- Replace with actual student ID
+  AND subject_name = 'Computer Programming'  -- Replace with actual subject
+  AND DATE(start_time) = CURDATE()
+  AND early_ended = TRUE;

--- a/ViewModels/StudentSessionDashboardViewModel.cs
+++ b/ViewModels/StudentSessionDashboardViewModel.cs
@@ -291,7 +291,9 @@ namespace LaboratorySitInSystem.ViewModels
         private void ExecuteEndSessionEarly(object parameter)
         {
             var result = MessageBox.Show(
-                "Are you sure you want to end your session early?\n\nYou will not be able to rejoin this session.",
+                "Are you sure you want to end your session early?\n\n" +
+                "⚠️ WARNING: You will NOT be able to rejoin this class session today.\n" +
+                "This action is permanent and cannot be undone.",
                 "End Session Early",
                 MessageBoxButton.YesNo,
                 MessageBoxImage.Warning);
@@ -301,7 +303,7 @@ namespace LaboratorySitInSystem.ViewModels
                 try
                 {
                     _sessionRepo.EndSessionEarly(ActiveSession.SessionId, DateTime.Now);
-                    StatusMessage = "Session ended. Returning to login...";
+                    StatusMessage = "Session ended early. You cannot rejoin this class today.";
 
                     // Notify that a session was ended
                     SessionEventHub.NotifySessionEnded(Student.StudentId);

--- a/ViewModels/StudentSitInViewModel.cs
+++ b/ViewModels/StudentSitInViewModel.cs
@@ -140,6 +140,15 @@ namespace LaboratorySitInSystem.ViewModels
                     System.Diagnostics.Debug.WriteLine($"[SITIN] DENIED: No active schedule at current time");
                     return;
                 }
+
+                // Check if student has ended their session early for this subject today
+                var hasEndedEarly = _sessionRepo.HasEndedSessionEarlyToday(StudentIdInput, schedule.SubjectName, now);
+                if (hasEndedEarly)
+                {
+                    StatusMessage = $"Access denied. You have already ended your session early for {schedule.SubjectName} today and cannot rejoin.";
+                    System.Diagnostics.Debug.WriteLine($"[SITIN] DENIED: Student ended session early for {schedule.SubjectName} today");
+                    return;
+                }
                 
                 System.Diagnostics.Debug.WriteLine($"[SITIN] ACCESS GRANTED: {schedule.SubjectName}");
                 MatchedSchedule = schedule;


### PR DESCRIPTION
## Description
Students can't rejoin after ending session early.

## Evidence
Attach or paste a screenshot/photo below as evidence.
<img width="977" height="634" alt="image" src="https://github.com/user-attachments/assets/a440a11b-90e5-42cb-903b-53cf55a2637c" />
